### PR TITLE
docs: enforce branch-first workflow in agent instructions

### DIFF
--- a/.instructions.md
+++ b/.instructions.md
@@ -156,9 +156,21 @@ Idea | Planning | Ready for Implementation | In Progress | Complete
 #### Branching Strategy
 - **main:** Production-ready code only
 - **dev:** Integration branch for active development
-- **feature/[name]:** New features (branch from `dev`)
-- **bugfix/[name]:** Bug fixes (branch from `dev`)
+- **feature/[name]:** New features (branch from `main`)
+- **bugfix/[name]:** Bug fixes (branch from `main`)
 - **hotfix/[name]:** Urgent fixes (branch from `main`)
+
+#### Mandatory Branch Sync Before New Work
+Before creating any new branch, update local `main` and `dev`:
+
+```bash
+git checkout main
+git pull origin main
+git checkout dev
+git pull origin dev
+```
+
+Never create a feature/bugfix branch from stale local refs.
 
 **Branch Naming:**
 - Use lowercase with hyphens: `feature/dispatcher-search`, `bugfix/timeout-handling`
@@ -198,6 +210,7 @@ Follow Conventional Commits specification:
 - **Start any new work:** Create a feature/bugfix branch immediately
 - **Multiple tasks:** Keep each feature/fix in its own branch
 - **Experiments:** Always use a branch; never experiment on `dev` or `main`
+- **Branch source:** All non-release work branches MUST start from `main`
 
 #### When to Commit
 - **Logical units of work:** One commit per complete, testable change
@@ -215,20 +228,22 @@ Follow Conventional Commits specification:
 - **Tests passing:** Full test suite passes locally
 - **Code reviewed:** If working with others, get review first
 - **Documentation updated:** README, CHANGELOG, and relevant docs current
-- **No conflicts:** Rebase or merge latest `dev` into your branch first
+- **No conflicts:** Rebase or merge latest `main` into your branch first
 
 **Merge Process:**
 ```bash
-# Update your branch with latest dev
-git checkout dev
-git pull origin dev
+# Update your branch with latest main
+git checkout main
+git pull origin main
 git checkout feature/your-feature
-git rebase dev  # or merge dev if you prefer
+git rebase main  # or merge main if you prefer
 
-# Merge into dev
-git checkout dev
-git merge --no-ff feature/your-feature  # keeps branch history
-git push origin dev
+# Open PR: feature/your-feature -> dev
+# Do not merge directly to dev from local git commands.
+
+# Release path
+# Open PR: dev -> main
+# After PR merge to main, create/publish release.
 
 # Clean up
 git branch -d feature/your-feature
@@ -237,14 +252,15 @@ git branch -d feature/your-feature
 #### When to Push
 - **End of work session:** Push branches to back up your work
 - **Before asking for help:** Push so others can see your code
-- **After merging:** Always push `dev` after merging features
-- **Main branch:** Only push after thorough testing and approval
+- **Protected branches:** Never push directly to `dev` or `main`; use PRs
+- **Main branch:** Changes only via approved PR from `dev`
 
 #### When to Pull
 - **Start of work session:** Pull latest changes before starting
-- **Before merging:** Ensure you have latest `dev` before merging your branch
+- **Before creating a branch:** Ensure both `main` and `dev` are updated locally
+- **Before merging:** Ensure you have latest `main` and `dev` before opening PR
 - **Conflicts reported:** Pull to get the conflicting changes
-- **Regularly:** Pull `dev` periodically to stay in sync (daily if active development)
+- **Regularly:** Pull `main` and `dev` periodically to stay in sync (daily if active development)
 
 ---
 


### PR DESCRIPTION
## Summary
- align `.instructions.md` with the required branching process
- require syncing local `main` and `dev` before creating branches
- require `feature/*` and `bugfix/*` branches to start from `main`
- require PR flow: `feature/* -> dev -> main`
- clarify no direct pushes to protected branches

## Testing
- documentation change only

## Notes
This codifies the agreed workflow and reduces branch-target drift.